### PR TITLE
Prevent menu from appearing offscreen

### DIFF
--- a/NewPopMenu.podspec
+++ b/NewPopMenu.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name         = 'NewPopMenu'
-  spec.version      = '2.0.0'
+  spec.version      = '2.1.1'
   spec.license      = { :type => 'MIT', :file => "LICENSE" }
   spec.homepage     = 'https://github.com/CaliCastle/PopMenu'
   spec.authors      = { 'Cali Castle' => 'cali@calicastle.com' }
   spec.summary      = 'A cool and customizable popup action sheet for iOS'
-  spec.source       = { :git => 'https://github.com/CaliCastle/PopMenu.git', :tag => 'v2.0.0' }
+  spec.source       = { :git => 'https://github.com/CaliCastle/PopMenu.git', :tag => 'v2.1.1' }
   spec.source_files = 'PopMenu/**/*.{h,swift}'
 
   spec.module_name = "PopMenu"

--- a/PopMenu/View Controller & Views/PopMenuViewController.swift
+++ b/PopMenu/View Controller & Views/PopMenuViewController.swift
@@ -342,10 +342,18 @@ extension PopMenuViewController {
     /// - Returns: The source origin point
     fileprivate func calculateContentOrigin(with size: CGSize) -> CGPoint {
         guard let sourceFrame = absoluteSourceFrame else { return CGPoint(x: view.center.x - size.width / 2, y: view.center.y - size.height / 2) }
+        let minContentPos: CGFloat = UIScreen.main.bounds.size.width * 0.05
+        let maxContentPos: CGFloat = UIScreen.main.bounds.size.width * 0.95
         
         // Get desired content origin point
         let offsetX = (size.width - sourceFrame.size.width ) / 2
         var desiredOrigin = CGPoint(x: sourceFrame.origin.x - offsetX, y: sourceFrame.origin.y)
+        if (desiredOrigin.x + size.width) > maxContentPos {
+            desiredOrigin.x = maxContentPos - size.width
+        }
+        if desiredOrigin.x < minContentPos {
+            desiredOrigin.x = minContentPos
+        }
         
         // Move content in place
         translateOverflowX(desiredOrigin: &desiredOrigin, contentSize: size)
@@ -415,12 +423,12 @@ extension PopMenuViewController {
             sizingLabel.text = action.title
             
             let desiredWidth = sizingLabel.sizeThatFits(view.bounds.size).width
-            contentFitWidth += min(desiredWidth, maxContentWidth)
+            contentFitWidth += desiredWidth
             
             contentFitWidth += action.iconWidthHeight
         }
         
-        return contentFitWidth
+        return min(contentFitWidth,maxContentWidth)
     }
     
     /// Setup actions view.


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/CaliCastle/PopMenu/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently the PopMenu can overflow offscreen - in calculateContentWidth() with a long text and on smaller screens (e.g. iPhone SE) the contentFitWidth can easily be larger than screen width. The menu can also overflow offscreen even when its width is not larger than screen width due to overflow checks missing in calculateContentOrigin()

### Description
* I've changed calculateContentWidth() so that the maximum contentFitWidth is 90% of screen width (maxContentWidth)
* Analogically in calculateContentOrigin() I've added minContentPos = 5% and maxContentPos = 95% of screen width, and clamped the popup between these positions.

The end result is that the popup menu can't overflow, max width is 90% of screen width, and there is always a 5% space between the edge of the screen and the menu. This is kinda arbitrary due to the existing "90% of screen" constraint already present, the constants can be changed (e.g. 100% width, 0% on the sides...), made configurable or whatever.
