### PR TITLE
Fix size of preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check out the [documentation and guides](https://popmenu.calicastle.com/) for de
 
 What's a better way to know what `PopMenu` offers than some live action images? Here's to show you what you can do with `PopMenu`:
 
-<p align="center"><img src="https://raw.githubusercontent.com/CaliCastle/PopMenu/master/.assets/Demo_Showcase.gif" width="250"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/CaliCastle/PopMenu/master/.assets/Demo_Showcase.gif" width="280"></p>
 
 ## 💪🏻 Contribute
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check out the [documentation and guides](https://popmenu.calicastle.com/) for de
 
 What's a better way to know what `PopMenu` offers than some live action images? Here's to show you what you can do with `PopMenu`:
 
-<p align="center"><img src="https://raw.githubusercontent.com/CaliCastle/PopMenu/master/.assets/Demo_Showcase.gif"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/CaliCastle/PopMenu/master/.assets/Demo_Showcase.gif" width="250"></p>
 
 ## 💪🏻 Contribute
 


### PR DESCRIPTION
<!-- Thanks for contributing to _PopMenu_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/CaliCastle/PopMenu/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Preview not fit on screens MacBook and other.

### Description
Set width to `280`. Attach screenshoot:

Before:

<img width="400" alt="Screenshot 2019-06-13 at 11 31 57" src="https://user-images.githubusercontent.com/10995774/59417020-23360400-8dcf-11e9-9213-3c7513cb34b7.png">

After:

<img width="400" alt="Screenshot 2019-06-13 at 11 32 19" src="https://user-images.githubusercontent.com/10995774/59417027-2630f480-8dcf-11e9-8a68-6c8bcf546014.png">
