### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "PopMenu",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "PopMenu", targets: ["PopMenu"])
+    ],
+    targets: [
+        .target(
+            name: "PopMenu",
+            path: "PopMenu"
+        ),
+        .testTarget(
+            name: "PopMenuTests",
+            dependencies: ["PopMenu"],
+            path: "PopMenuTests"
+        )
+    ]
+)


### PR DESCRIPTION
<!-- Thanks for contributing to _PopMenu_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes([demo branch](https://github.com/TwoDollarsEsq/PopMenu/tree/SPM-Demo)).
- [x] I've read the [Contribution Guidelines](https://github.com/CaliCastle/PopMenu/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows to use this library with Swift Package Manager. Since Xcode 11 using SPM is extremely easy due to its integration into IDE, so it is good thing for every framework that is targeted to platforms that support Swift to be able to be used with SPM.

### Description
<!--- Describe your changes in detail. -->
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.