### PR TITLE
make pop menu above source view

### DIFF
--- a/PopMenu/Classes/PopMenuAppearance.swift
+++ b/PopMenu/Classes/PopMenuAppearance.swift
@@ -50,6 +50,9 @@ final public class PopMenuAppearance: NSObject {
     
     /// The presentation style
     public var popMenuPresentationStyle: PopMenuPresentationStyle = .cover()
+    
+    /// The menu will overlay on source view or not
+    public var popMenuAboveSourceView = false
 
 }
 

--- a/PopMenu/View Controller & Views/PopMenuViewController.swift
+++ b/PopMenu/View Controller & Views/PopMenuViewController.swift
@@ -361,6 +361,23 @@ extension PopMenuViewController {
             desiredOrigin.x = minContentPos
         }
         
+        if appearance.popMenuAboveSourceView {
+            let minContentPos: CGFloat = UIScreen.main.bounds.size.height * 0.05
+            let maxContentPos: CGFloat = UIScreen.main.bounds.size.height * 0.95
+            
+            let offsetY = sourceFrame.size.height
+            desiredOrigin.y += offsetY
+            if (desiredOrigin.y + size.height) > maxContentPos {
+                desiredOrigin.y -= 2 * offsetY
+            }
+            if (desiredOrigin.y + size.height) > maxContentPos {
+                desiredOrigin.y = maxContentPos - size.height
+            }
+            if desiredOrigin.y < minContentPos {
+                desiredOrigin.y = minContentPos
+            }
+        }
+        
         // Move content in place
         translateOverflowX(desiredOrigin: &desiredOrigin, contentSize: size)
         translateOverflowY(desiredOrigin: &desiredOrigin, contentSize: size)


### PR DESCRIPTION
<!-- Thanks for contributing to _PopMenu_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [v] I've tested my changes.
- [v] I've read the [Contribution Guidelines](https://github.com/CaliCastle/PopMenu/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I want the pop menu above source view like system menu view controller

### Description
<!--- Describe your changes in detail. -->

add a parameter *popMenuAboveSourceView* in PopMenuAppearance
default is false like now
if set it true, the pop menu will above source view upper or downer