### PR TITLE
Fix build when using mixed objc/swift projects

### DIFF
--- a/PopMenu/View Controller & Views/PopMenuViewController.swift
+++ b/PopMenu/View Controller & Views/PopMenuViewController.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 /// Delegate for handling PopMenu selection.
-@objc public protocol PopMenuViewControllerDelegate: class {
+public protocol PopMenuViewControllerDelegate: class {
     /// Called when an action is selected.
-    @objc optional func popMenuDidSelectItem(_ popMenuViewController: PopMenuViewController, at index: Int)
+    optional func popMenuDidSelectItem(_ popMenuViewController: PopMenuViewController, at index: Int)
 }
 
 final public class PopMenuViewController: UIViewController {
@@ -623,7 +623,7 @@ extension PopMenuViewController {
         }
         
         // Notify delegate
-        delegate?.popMenuDidSelectItem?(self, at: index)
+        delegate?.popMenuDidSelectItem(self, at: index)
         
         // Should dismiss or not
         if shouldDismissOnSelection {


### PR DESCRIPTION
Remove @objc modifiers. They cause mixed objc/swift projects to fail to compile because any class that uses the delegate won't be able to find the delegate definition in the bridge file. 

This is because the protocol passes PopMenuViewController but that class is not @objc compatible.  

Remove the @objc, remove the optional because it requires objc. It's irrelevant anyway because there is only one function, therefore anyone passing in the delegate should implement that function

<!-- Thanks for contributing to _PopMenu_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ x] I've tested my changes.
- [ x] I've read the [Contribution Guidelines](https://github.com/CaliCastle/PopMenu/blob/master/CONTRIBUTING.md).
- [ x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
You cannot use a swift class that implements the delegate if you are in a mixed objc/swift environment. The class is automatically bridged because the protocol is marked @objc

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail. -->
