### PR TITLE
Add support for specifying max width

### DIFF
--- a/PopMenu.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/PopMenu.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PreviewsEnabled</key>
-	<false/>
-</dict>
-</plist>

--- a/PopMenu.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/PopMenu.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/PopMenu/Classes/PopMenuAppearance.swift
+++ b/PopMenu/Classes/PopMenuAppearance.swift
@@ -17,6 +17,8 @@ public typealias Color = UIColor
 /// Appearance for PopMenu.
 /// Use for configuring custom styles and looks.
 final public class PopMenuAppearance: NSObject {
+    /// The minimum width for the menu; Default: auto-sizing
+    public var popMenuMinimumWidth: CGFloat? = .none
     
     /// Background and tint colors.
     public var popMenuColor: PopMenuColor = .default()

--- a/PopMenu/View Controller & Views/PopMenuViewController.swift
+++ b/PopMenu/View Controller & Views/PopMenuViewController.swift
@@ -434,7 +434,12 @@ extension PopMenuViewController {
             contentFitWidth += action.iconWidthHeight
         }
         
-        return min(contentFitWidth,maxContentWidth)
+      
+        if let minimumWidth = self.appearance.popMenuMinimumWidth {
+            return max(minimumWidth, min(contentFitWidth,maxContentWidth))
+        } else {
+            return min(contentFitWidth,maxContentWidth)
+        }
     }
     
     /// Setup actions view.


### PR DESCRIPTION
<!-- Thanks for contributing to _PopMenu_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/CaliCastle/PopMenu/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Wanted more control over the width of the menu; Also fixes #33 

### Description
Added a property in PopMenuAppearance that allows you to set the minimum width the menu should try to maintain. Setting it to `nil` or `.none` will revert to the old implementation.
